### PR TITLE
Rickles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # shellconfig
 public shell scripts for init themes, etc.
+
+
+# debian-shellinit.sh
+
+This script should be executed without Sudo, but passwords will have to be provided for sudo executions and chsh within the script.

--- a/debian-shellinit.sh
+++ b/debian-shellinit.sh
@@ -15,7 +15,9 @@ sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/too
 # Set the theme to 'darkblood'
 sudo sed -i 's/ZSH_THEME=".*"/ZSH_THEME="darkblood"/' ~/.zshrc
 
-# Apply changes
-exec zsh
-
+#Install complete
 echo "Installation and configuration complete!"
+
+chsh -s /bin/zsh $USER
+
+exec zsh


### PR DESCRIPTION
This change reordered the installation complete message as it was getting lost as exec zsh changed the current shell. 

Also this change added the new shell afterwards and added chsh command to change the $USER default shell to utilize zsh. This solves the issue #1 , as tmux will utilize the default shell, which will now be zsh. /bin/bash can be called now explicitly as required. 